### PR TITLE
Add pre-push Git Hook and addPrePushGitHook task

### DIFF
--- a/.scripts/pre-push
+++ b/.scripts/pre-push
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Run spotlessApply using ./gradlew before pushing
+
+COMMAND="./gradlew --quiet spotlessCheck"
+
+echo "Running spotlessCheck..."
+eval "$COMMAND"
+RESULT=$?
+
+if [ $RESULT -ne 0 ]; then
+  echo "spotlessCheck failed. Please fix the formatting issues before pushing. (./gradlew spotlessApply)"
+  exit 1
+fi
+
+echo "spotlessCheck passed."
+exit 0

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,12 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
+tasks.register('addPrePushGitHook', Copy) {
+    from ".scripts/pre-push"
+    into ".git/hooks"
+    fileMode 0777
+}
+
 tasks.named('test') {
     useJUnitPlatform()
 }


### PR DESCRIPTION
This hook runs spotlessApply before pushing to remote branch.

Run ./gradlew addPreCommitGitHookOnBuild to enable this hook.